### PR TITLE
Update NODE_VERSION for expose-fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /home/learner
 RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
 
 # change it to your required node version
-ENV NODE_VERSION 5.1.0
+ENV NODE_VERSION 12.18.3
 
 # needed by nvm install
 ENV NVM_DIR /home/learner/.nvm


### PR DESCRIPTION
expose-fs would fail on nodejs 5.1.0, printing `>> .fs.out 2>> .fs.err &` in
the terminal window. Switching to a recent nodejs version solved the problem.